### PR TITLE
Fix background download process

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,6 +2,10 @@ FROM node:18-alpine
 
 WORKDIR /app
 
+# Install Python and yt-dlp for background downloads
+RUN apk add --no-cache python3 py3-pip \
+    && pip3 install --no-cache-dir yt-dlp
+
 # Copy package files
 COPY package*.json ./
 
@@ -18,4 +22,4 @@ RUN mkdir -p uploads output temp
 EXPOSE 3001
 
 # Start the application
-CMD ["npm", "start"] 
+CMD ["npm", "start"]

--- a/backend/src/routes/backgrounds.js
+++ b/backend/src/routes/backgrounds.js
@@ -35,17 +35,27 @@ router.post('/download', (req, res) => {
   const pythonScript = path.join(__dirname, '..', '..', '..', 'video-processor', 'download_from_url.py');
 
   try {
-    const pythonProcess = spawn('python', ['-u', pythonScript, '--url', youtubeUrl, '--output-dir', categoryDir], {
-      detached: true,
-      stdio: 'ignore'
+    const pythonProcess = spawn('python3', ['-u', pythonScript, '--url', youtubeUrl, '--output-dir', categoryDir]);
+
+    pythonProcess.stdout.on('data', (data) => {
+      console.log(`[PYTHON STDOUT] ${data}`);
+    });
+
+    pythonProcess.stderr.on('data', (data) => {
+      console.error(`[PYTHON STDERR] ${data}`);
     });
 
     pythonProcess.on('error', (err) => {
-      // This will log an error if the process fails to start.
       console.error('Failed to start Python download process:', err);
     });
 
-    pythonProcess.unref();
+    pythonProcess.on('close', (code) => {
+      if (code !== 0) {
+        console.error(`Download process exited with code ${code}`);
+      } else {
+        console.log('Background video download completed successfully');
+      }
+    });
 
     res.status(202).json({ message: 'Download started successfully! The video will appear in the list shortly.' });
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       - /app/node_modules
       - ./uploads:/app/uploads
       - ./output:/app/output
+      - ./video-processor:/app/video-processor
     depends_on:
       - video-processor
 

--- a/history.md
+++ b/history.md
@@ -1,5 +1,28 @@
 # Project Change History
 
+## 2025-07-16 at 05:11 - Backend YouTube Download Fix
+
+### Modified Files
+- `backend/Dockerfile`
+- `docker-compose.yml`
+- `backend/src/routes/backgrounds.js`
+
+### Change Description
+- Added Python3 and yt-dlp installation to backend Dockerfile
+- Mounted `video-processor` directory in backend service via docker-compose
+- Updated background download route to use `python3`, log output, and remove detached spawn
+
+### Rationale
+- Enable YouTube video downloads from the backend container
+- Surface errors from the Python download process for easier debugging
+
+### Potential Impacts
+- Backend image size increases slightly due to Python installation
+- Download logs now appear in backend container output
+
+### Implemented By
+- AI Assistant
+
 ## 2024-02-15 at 15:45 - YouTube Downloader Implementation
 
 ### Modified Files


### PR DESCRIPTION
## Summary
- install Python and yt-dlp in the backend image
- mount video-processor folder for access to scripts
- log background download output and use `python3`
- document changes in `history.md`

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6876d0756ce48333a159cfdc36aec596