### PR TITLE
Enable multi-voice selection with audio preview

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -11,6 +11,7 @@ const scrapeRoutes = require('./routes/scrape');
 const postsRoutes = require('./routes/posts');
 const backgroundRoutes = require('./routes/backgrounds');
 const videosRoutes = require('./routes/videos');
+const ttsRoutes = require('./routes/tts');
 const { initializeDatabase } = require('./utils/database');
 
 const app = express();
@@ -53,6 +54,7 @@ app.use('/api/scrape', scrapeRoutes);
 app.use('/api/posts', postsRoutes);
 app.use('/api/backgrounds', backgroundRoutes);
 app.use('/api/videos', videosRoutes);
+app.use('/api/tts', ttsRoutes);
 
 // Serve generated videos from the root output folder
 app.use('/output', express.static(path.join(__dirname, '..', '..', 'output')));

--- a/backend/src/routes/tts.js
+++ b/backend/src/routes/tts.js
@@ -1,0 +1,42 @@
+const express = require('express');
+const { v4: uuidv4 } = require('uuid');
+const { spawn } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+
+const router = express.Router();
+
+router.post('/preview', (req, res) => {
+  const { voiceType } = req.body;
+  if (!voiceType) {
+    return res.status(400).json({ error: 'voiceType is required' });
+  }
+
+  const pythonScript = path.join(__dirname, '..', '..', '..', 'video-processor', 'tts_preview.py');
+  const tempDir = path.join(__dirname, '..', '..', 'temp');
+  if (!fs.existsSync(tempDir)) {
+    fs.mkdirSync(tempDir, { recursive: true });
+  }
+  const outputPath = path.join(tempDir, `${uuidv4()}.mp3`);
+
+  const pythonProcess = spawn('python', [pythonScript, '--voice-type', voiceType, '--output-path', outputPath]);
+
+  let stderrData = '';
+  pythonProcess.stderr.on('data', (data) => {
+    stderrData += data.toString();
+  });
+
+  pythonProcess.on('close', (code) => {
+    if (code === 0) {
+      res.sendFile(outputPath, (err) => {
+        fs.unlink(outputPath, () => {});
+        if (err) console.error('Error sending preview file:', err);
+      });
+    } else {
+      console.error('TTS preview failed:', stderrData);
+      res.status(500).json({ error: 'Failed to generate preview' });
+    }
+  });
+});
+
+module.exports = router;

--- a/frontend/src/app/generate/page.tsx
+++ b/frontend/src/app/generate/page.tsx
@@ -31,6 +31,12 @@ export default function GeneratePage() {
   const [backgroundType, setBackgroundType] = useState('');
   const [backgroundCategories, setBackgroundCategories] = useState<string[]>([]);
   const [voiceType, setVoiceType] = useState('female');
+  const voiceOptions = [
+    { value: 'female', label: 'Female (Aria)' },
+    { value: 'jenny', label: 'Female (Jenny)' },
+    { value: 'male', label: 'Male (Guy)' },
+    { value: 'davis', label: 'Male (Davis)' }
+  ];
   const [job, setJob] = useState<VideoJob | null>(null);
   const [loading, setLoading] = useState(false);
 
@@ -133,6 +139,24 @@ export default function GeneratePage() {
         console.error('Error polling job status:', error);
       }
     }, 2000);
+  };
+
+  const handlePreviewVoice = async () => {
+    try {
+      const response = await fetch('/api/tts/preview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ voiceType })
+      });
+      if (!response.ok) throw new Error('Preview failed');
+      const blob = await response.blob();
+      const url = URL.createObjectURL(blob);
+      const audio = new Audio(url);
+      audio.play();
+    } catch (err) {
+      console.error('Voice preview error:', err);
+      toast.error('Failed to preview voice');
+    }
   };
 
   const handlePostSelect = (post: SavedPost) => {
@@ -313,17 +337,27 @@ export default function GeneratePage() {
 
                 {/* Voice Type */}
                 <div>
-                  <label className="block text-gray-900 font-medium mb-2">
-                    Voice
-                  </label>
-                  <select
-                    value={voiceType}
-                    onChange={(e) => setVoiceType(e.target.value)}
-                    className="form-input w-full px-4 py-3"
-                  >
-                    <option value="male">Male</option>
-                    <option value="female">Female</option>
-                  </select>
+                  <label className="block text-gray-900 font-medium mb-2">Voice</label>
+                  <div className="flex gap-2">
+                    <select
+                      value={voiceType}
+                      onChange={(e) => setVoiceType(e.target.value)}
+                      className="form-input flex-1 px-4 py-3"
+                    >
+                      {voiceOptions.map((opt) => (
+                        <option key={opt.value} value={opt.value}>
+                          {opt.label}
+                        </option>
+                      ))}
+                    </select>
+                    <button
+                      type="button"
+                      onClick={handlePreviewVoice}
+                      className="btn-secondary whitespace-nowrap"
+                    >
+                      Preview
+                    </button>
+                  </div>
                 </div>
 
                 {/* Generate Button */}

--- a/history.md
+++ b/history.md
@@ -105,3 +105,28 @@
 
 ### Implemented By
 - Initial Project Setup Team 
+## 2025-07-17 at 23:29 - Multiple Voice Selection and Preview
+
+### Modified Files
+- `video-processor/text_to_speech.py`
+- `video-processor/tts_preview.py`
+- `backend/src/routes/tts.js`
+- `backend/src/index.js`
+- `frontend/src/app/generate/page.tsx`
+
+### Change Description
+- Added additional voice configurations (Aria, Jenny, Guy, Davis)
+- Created new Python script and backend route for generating short voice previews
+- Registered `/api/tts` routes in backend server
+- Updated frontend generation page with new voice options and a Preview button
+
+### Rationale
+- Allow users to choose from multiple text-to-speech voices
+- Enable quick audio previews before generating full videos
+
+### Potential Impacts
+- Requires Python environment to run new preview script
+- Slight increase in backend complexity and API surface
+
+### Implemented By
+- AI Assistant

--- a/video-processor/text_to_speech.py
+++ b/video-processor/text_to_speech.py
@@ -9,24 +9,31 @@ import edge_tts
 from utils.logger import setup_logger
 
 class TextToSpeechGenerator:
-    def __init__(self, voice_type: str = 'female_fast'):
+    def __init__(self, voice_type: str = 'female'):
         self.logger = setup_logger('text_to_speech')
         
         # Voice and rate configuration using edge-tts voices
-        # A good voice is 'en-US-AriaNeural'. '+' indicates a faster rate.
         self.voice_config = {
-            'female_fast': {
+            'female': {
                 'voice': 'en-US-AriaNeural',
-                'rate': '+20%'  # 20% faster than normal
+                'rate': '+20%'
             },
-            'male_normal': {
+            'male': {
                 'voice': 'en-US-GuyNeural',
                 'rate': 'default'
+            },
+            'jenny': {
+                'voice': 'en-US-JennyNeural',
+                'rate': 'default'
+            },
+            'davis': {
+                'voice': 'en-US-DavisNeural',
+                'rate': '-10%'
             }
         }
         
         # Set the selected voice and rate
-        config = self.voice_config.get(voice_type, self.voice_config['female_fast'])
+        config = self.voice_config.get(voice_type, self.voice_config['female'])
         self.voice = config['voice']
         self.rate = config['rate']
 

--- a/video-processor/tts_preview.py
+++ b/video-processor/tts_preview.py
@@ -1,0 +1,18 @@
+import argparse
+from pathlib import Path
+from text_to_speech import TextToSpeechGenerator
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate a short TTS preview")
+    parser.add_argument("--voice-type", default="female", help="Voice type key")
+    parser.add_argument("--output-path", required=True, help="Where to save mp3")
+    args = parser.parse_args()
+
+    generator = TextToSpeechGenerator(voice_type=args.voice_type)
+    sample_text = "This is a sample of my voice."
+    generator.generate_speech(sample_text, Path(args.output_path))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- extend available voices for text-to-speech
- add Python utility and backend route for generating preview clips
- expose `/api/tts/preview` in backend server
- update generation UI with new voice options and preview button
- log changes in `history.md`

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879863851448333883a035dba721a65