### PR TITLE
Fix TTS rate settings

### DIFF
--- a/history.md
+++ b/history.md
@@ -23,6 +23,24 @@
 ### Implemented By
 - AI Assistant
 
+## 2025-07-18 at 01:01 - Fix Invalid TTS Rate
+
+### Modified Files
+- `video-processor/text_to_speech.py`
+
+### Change Description
+- Replaced invalid `'default'` rate values for male and jenny voices with `'+0%'`
+  to comply with edge-tts requirements.
+
+### Rationale
+- Prevent runtime errors when generating speech previews.
+
+### Potential Impacts
+- TTS output speed for male and jenny voices now matches the default rate.
+
+### Implemented By
+- AI Assistant
+
 ## 2024-02-15 at 15:45 - YouTube Downloader Implementation
 
 ### Modified Files

--- a/video-processor/text_to_speech.py
+++ b/video-processor/text_to_speech.py
@@ -20,11 +20,11 @@ class TextToSpeechGenerator:
             },
             'male': {
                 'voice': 'en-US-GuyNeural',
-                'rate': 'default'
+                'rate': '+0%'
             },
             'jenny': {
                 'voice': 'en-US-JennyNeural',
-                'rate': 'default'
+                'rate': '+0%'
             },
             'davis': {
                 'voice': 'en-US-DavisNeural',


### PR DESCRIPTION
## Summary
- fix invalid rate config in TextToSpeechGenerator
- document change in history log

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68799c796eb08333823b5c6698fcde75