### PR TITLE
Add AI chat page

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A full-stack application that automatically creates narrated Reddit story videos
 - 🎥 **Background Videos**: Download and use YouTube videos as backgrounds
 - 📱 **Modern UI**: Clean, responsive frontend interface
 - 🔧 **Configurable**: Customize video length, voice, background type, and more
+- 💬 **AI Story Chat**: Brainstorm story ideas with an integrated OpenRouter chat
 
 ## Tech Stack
 
@@ -75,6 +76,7 @@ RedditStories/
 - **REDDIT_CLIENT_ID**: Your Reddit app client ID
 - **REDDIT_CLIENT_SECRET**: Your Reddit app client secret
 - **REDDIT_USER_AGENT**: Your app user agent string
+- **OPENROUTER_API_KEY**: API key for OpenRouter chat completions
 
 ## API Endpoints
 

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -12,6 +12,7 @@ const postsRoutes = require('./routes/posts');
 const backgroundRoutes = require('./routes/backgrounds');
 const videosRoutes = require('./routes/videos');
 const ttsRoutes = require('./routes/tts');
+const chatRoutes = require('./routes/chat');
 const { initializeDatabase } = require('./utils/database');
 
 const app = express();
@@ -55,6 +56,7 @@ app.use('/api/posts', postsRoutes);
 app.use('/api/backgrounds', backgroundRoutes);
 app.use('/api/videos', videosRoutes);
 app.use('/api/tts', ttsRoutes);
+app.use('/api/chat', chatRoutes);
 
 // Serve generated videos from the root output folder
 app.use('/output', express.static(path.join(__dirname, '..', '..', 'output')));

--- a/backend/src/routes/chat.js
+++ b/backend/src/routes/chat.js
@@ -1,0 +1,39 @@
+const express = require('express');
+const axios = require('axios');
+require('dotenv').config();
+
+const router = express.Router();
+
+// Proxy endpoint to chat with OpenRouter AI
+router.post('/', async (req, res) => {
+  const { messages } = req.body;
+  if (!messages || !Array.isArray(messages)) {
+    return res.status(400).json({ error: 'messages array is required' });
+  }
+  const apiKey = process.env.OPENROUTER_API_KEY;
+  if (!apiKey) {
+    return res.status(500).json({ error: 'OpenRouter API key not configured' });
+  }
+  try {
+    const response = await axios.post(
+      'https://openrouter.ai/api/v1/chat/completions',
+      {
+        model: 'openrouter/auto',
+        messages,
+      },
+      {
+        headers: {
+          'Authorization': `Bearer ${apiKey}`,
+          'Content-Type': 'application/json'
+        }
+      }
+    );
+    res.json(response.data);
+  } catch (error) {
+    console.error('OpenRouter API error:', error.response?.data || error.message);
+    const status = error.response?.status || 500;
+    res.status(status).json({ error: 'Failed to fetch completion' });
+  }
+});
+
+module.exports = router;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       - REDDIT_CLIENT_ID=${REDDIT_CLIENT_ID}
       - REDDIT_CLIENT_SECRET=${REDDIT_CLIENT_SECRET}
       - REDDIT_USER_AGENT=RedditStoryGenerator/1.0
+      - OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
     volumes:
       - ./backend:/app
       - /app/node_modules

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -59,11 +59,17 @@ export default function RootLayout({
                 >
                   📹 My Videos
                 </Link>
-                <Link 
-                  href="/backgrounds" 
+                <Link
+                  href="/backgrounds"
                   className="px-4 py-2.5 rounded-lg bg-gray-50 hover:bg-gray-100 text-gray-700 hover:text-gray-900 border border-gray-200 hover:border-gray-300 transition-all duration-200 text-sm font-medium"
                 >
                   🎨 Backgrounds
+                </Link>
+                <Link
+                  href="/story-ai"
+                  className="px-4 py-2.5 rounded-lg bg-gray-50 hover:bg-gray-100 text-gray-700 hover:text-gray-900 border border-gray-200 hover:border-gray-300 transition-all duration-200 text-sm font-medium"
+                >
+                  💬 AI Chat
                 </Link>
               </div>
             </div>

--- a/frontend/src/app/story-ai/page.tsx
+++ b/frontend/src/app/story-ai/page.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useState } from 'react';
+import { Send } from 'lucide-react';
+import Link from 'next/link';
+
+interface Message {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+export default function StoryAIPage() {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const sendMessage = async () => {
+    if (!input.trim()) return;
+    const updated = [...messages, { role: 'user', content: input }];
+    setMessages(updated);
+    setInput('');
+    setLoading(true);
+    try {
+      const res = await fetch('/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ messages: updated })
+      });
+      const data = await res.json();
+      if (res.ok) {
+        const ai = data.choices?.[0]?.message?.content || 'No response';
+        setMessages([...updated, { role: 'assistant', content: ai }]);
+      } else {
+        setMessages([...updated, { role: 'assistant', content: data.error || 'Error from API' }]);
+      }
+    } catch (err) {
+      setMessages([...updated, { role: 'assistant', content: 'Failed to reach server' }]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-white">
+      <div className="container mx-auto px-4 py-8">
+        <div className="mb-6 flex justify-between items-center">
+          <h1 className="text-3xl font-bold text-gray-900">AI Story Chat</h1>
+          <Link href="/" className="btn-secondary">Home</Link>
+        </div>
+        <div className="space-y-4 mb-4 max-h-[60vh] overflow-y-auto p-4 bg-white rounded-lg border border-gray-200">
+          {messages.map((m, idx) => (
+            <div key={idx} className={m.role === 'user' ? 'text-right' : 'text-left'}>
+              <span className={`inline-block px-3 py-2 rounded-lg max-w-full break-words ${m.role === 'user' ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-900'}`}>
+                {m.content}
+              </span>
+            </div>
+          ))}
+          {loading && <div className="text-gray-500">Thinking...</div>}
+        </div>
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter') sendMessage(); }}
+            className="form-input flex-1 px-4 py-3"
+            placeholder="Ask the AI for a story idea..."
+          />
+          <button
+            onClick={sendMessage}
+            disabled={loading}
+            className="btn-primary flex items-center gap-2 disabled:bg-gray-400"
+          >
+            <Send className="w-5 h-5" />
+            Send
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/history.md
+++ b/history.md
@@ -23,6 +23,34 @@
 ### Implemented By
 - AI Assistant
 
+## 2025-07-18 at 01:41 - AI Story Chat Page
+
+### Modified Files
+- `backend/src/routes/chat.js`
+- `backend/src/index.js`
+- `docker-compose.yml`
+- `frontend/src/app/story-ai/page.tsx`
+- `frontend/src/app/layout.tsx`
+- `README.md`
+
+### Change Description
+- Added new backend route proxying to OpenRouter API for AI chat
+- Registered `/api/chat` route in Express server and environment variable
+- Created story AI page in frontend with chat interface using the route
+- Linked new page in site navigation
+- Documented new environment variable and feature
+
+### Rationale
+- Allow users to generate story ideas via AI chat
+- Provide direct OpenRouter integration for brainstorming scripts
+
+### Potential Impacts
+- Requires `OPENROUTER_API_KEY` environment variable
+- Chat API errors may be surfaced to users
+
+### Implemented By
+- AI Assistant
+
 ## 2025-07-18 at 01:01 - Fix Invalid TTS Rate
 
 ### Modified Files


### PR DESCRIPTION
## Summary
- create `chat.js` backend route that proxies to OpenRouter
- expose `/api/chat` from Express server
- mount `OPENROUTER_API_KEY` in docker-compose
- add new `story-ai` page with chat UI
- link AI chat page in navigation
- document feature and new env variable
- log changes in `history.md`

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6879a4b666ec8333b524f7302c4c01e6